### PR TITLE
Clarify viewing distance in procedure

### DIFF
--- a/preregistration.md
+++ b/preregistration.md
@@ -48,7 +48,7 @@ Five participants with normal or corrected-to-normal vision will complete the st
 
 ### Procedure
 
-1. Participants sit at a comfortable viewing distance from the tachistoscope
+1. Participants sit at a comfortable viewing distance from their computer monitor.
 2. On each trial:
    - Two squares appear simultaneously (reference and comparison)
    - The participant judges which square is larger by pressing a corresponding button


### PR DESCRIPTION
Updated the procedure to specify viewing distance from the computer monitor instead of the tachistoscope.